### PR TITLE
Added validation for maximum number of admins in a community where ma…

### DIFF
--- a/src/comunidades/comunidades.service.ts
+++ b/src/comunidades/comunidades.service.ts
@@ -126,11 +126,19 @@ export class ComunidadesService {
     // don't catch and rethrow exception here, as the intention is
     // to let it go back to the gateway
     await this.getCommunityUser(communityAdminUser);
+    
+    const communityId = communityAdminUser.communityId;
+
+    const listOfAdminUsers = await this.getAdminUsers(communityId);
 
     const relation = new this.userAdminRelationModel(communityAdminUser);
 
     try {
-      return await relation.save();
+      if(listOfAdminUsers.length >= 3) {
+        throw new MicrosserviceException("Reached the maximum number of admins (3) for this community.", HttpStatus.BAD_REQUEST);
+      } else {
+        return await relation.save();
+      }
     } catch (err) {
       throw new MicrosserviceException(err.message, HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
…ximum is 3

## Motivação
- De acordo com as regras de negócio, cada comunidade pode conter no máximo 3 usuários com perfil de **Administrador**
- O Endpoint *community/addAdminUser* permitia a adição de membros administradores sem esse rigor.

## Mudanças feitas
- A função relacionada à adição de membros com perfil **Administrador** a uma determinada comunidade recebeu uma validação em que não é permitida a adição no caso de já existirem 3 ou mais usuários cadastrados na comunidade com esse perfil.
- Em caso de tentativa, a api retorna erro com status 400 e uma mensagem descritiva.

![Captura de tela de 2022-03-18 11-02-58](https://user-images.githubusercontent.com/48565496/159021180-68373072-ce04-46fd-8a8b-c44ea9609ea5.png)

## Tarefa relacionada

> 96-adicionar-líder-a-comunidade
